### PR TITLE
[BE] 음식 카테고리 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/multi/mariage/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/multi/mariage/category/controller/CategoryController.java
@@ -2,8 +2,10 @@ package com.multi.mariage.category.controller;
 
 import com.multi.mariage.category.dto.response.DrinkLowerCategoryResponse;
 import com.multi.mariage.category.dto.response.DrinkUpperCategoryResponse;
+import com.multi.mariage.category.dto.response.FoodCategoryResponse;
 import com.multi.mariage.category.service.DrinkLowerCategoryService;
 import com.multi.mariage.category.service.DrinkUpperCategoryService;
+import com.multi.mariage.category.service.FoodCategoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryController {
     private final DrinkUpperCategoryService drinkUpperCategoryService;
     private final DrinkLowerCategoryService drinkLowerCategoryService;
+    private final FoodCategoryService foodCategoryService;
 
     @GetMapping("/categories/upper")
     public ResponseEntity<DrinkUpperCategoryResponse> findUpperCategories() {
@@ -26,6 +29,12 @@ public class CategoryController {
     @GetMapping("/categories/lower")
     public ResponseEntity<DrinkLowerCategoryResponse> findLowerCategories() {
         DrinkLowerCategoryResponse response = drinkLowerCategoryService.findCategories();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/categories/food")
+    public ResponseEntity<FoodCategoryResponse> findFoodCategories() {
+        FoodCategoryResponse response = foodCategoryService.findCategories();
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/multi/mariage/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/multi/mariage/category/controller/CategoryController.java
@@ -34,7 +34,7 @@ public class CategoryController {
 
     @GetMapping("/categories/food")
     public ResponseEntity<FoodCategoryResponse> findFoodCategories() {
-        FoodCategoryResponse response = foodCategoryService.findCategories();
+        FoodCategoryResponse response = foodCategoryService.findFoodCategories();
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/multi/mariage/category/domain/FoodCategory.java
+++ b/backend/src/main/java/com/multi/mariage/category/domain/FoodCategory.java
@@ -4,17 +4,16 @@ import lombok.Getter;
 
 @Getter
 public enum FoodCategory {
-    //TODO: 명칭 더 가시적으로 변경 필요
     SEAFOOD(1, "해산물"),
-    MEAT(2, "고기/구이"),
+    ROAST(2, "고기/구이"),
     JOKBAL(3, "족발/보쌈"),
     JJIGAE(4, "찜/탕/찌개"),
     RICE(5, "밥/면"),
     PIZZA(6, "피자"),
     CHICKEN(7, "치킨"),
-    PASTA(8, "양식"),
-    CHINA(9, "중식"),
-    JAPAN(10, "돈까스/회/일식"),
+    ITALIAN(8, "양식"),
+    CHINESE(9, "중식"),
+    JAPANESE(10, "돈까스/회/일식"),
     ASIAN(11, "아시안"),
     MEXICAN(12, "멕시코"),
     BURGER(13, "햄버거"),

--- a/backend/src/main/java/com/multi/mariage/category/dto/response/FoodCategoryResponse.java
+++ b/backend/src/main/java/com/multi/mariage/category/dto/response/FoodCategoryResponse.java
@@ -15,8 +15,16 @@ public class FoodCategoryResponse {
     private int length;
 
     @Builder
-    public FoodCategoryResponse(List<FoodCategoriesVO> category, int length) {
+    private FoodCategoryResponse(List<FoodCategoriesVO> category, int length) {
         this.category = category;
         this.length = length;
     }
+
+    public static FoodCategoryResponse from(List<FoodCategoriesVO> category) {
+        return FoodCategoryResponse.builder()
+                .category(category)
+                .length(category.size())
+                .build();
+    }
+
 }

--- a/backend/src/main/java/com/multi/mariage/category/dto/response/FoodCategoryResponse.java
+++ b/backend/src/main/java/com/multi/mariage/category/dto/response/FoodCategoryResponse.java
@@ -1,11 +1,22 @@
 package com.multi.mariage.category.dto.response;
 
+import com.multi.mariage.category.vo.food.FoodCategoriesVO;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 public class FoodCategoryResponse {
+    private List<FoodCategoriesVO> category;
+    private int length;
 
+    @Builder
+    public FoodCategoryResponse(List<FoodCategoriesVO> category, int length) {
+        this.category = category;
+        this.length = length;
+    }
 }

--- a/backend/src/main/java/com/multi/mariage/category/service/FoodCategoryService.java
+++ b/backend/src/main/java/com/multi/mariage/category/service/FoodCategoryService.java
@@ -17,15 +17,12 @@ import java.util.stream.Collectors;
 
 @Service
 public class FoodCategoryService {
-    public FoodCategoryResponse findCategories() {
+    public FoodCategoryResponse findFoodCategories() {
 
         List<FoodCategory> categories = Arrays.asList(FoodCategory.values());
 
         List<FoodCategoriesVO> categoryList = categories.stream()
-                .map(category -> FoodCategoriesVO.builder()
-                        .id(category.getId())
-                        .name(category.getName())
-                        .build())
+                .map(category -> FoodCategoriesVO.from(category.getId(), category.getName()))
                 .toList();
 
         FoodCategoryResponse response = FoodCategoryResponse.builder()
@@ -35,6 +32,4 @@ public class FoodCategoryService {
 
         return response;
     }
-
-
 }

--- a/backend/src/main/java/com/multi/mariage/category/service/FoodCategoryService.java
+++ b/backend/src/main/java/com/multi/mariage/category/service/FoodCategoryService.java
@@ -1,19 +1,12 @@
 package com.multi.mariage.category.service;
 
-import com.multi.mariage.category.domain.DrinkUpperCategory;
 import com.multi.mariage.category.domain.FoodCategory;
-import com.multi.mariage.category.domain.Region;
-import com.multi.mariage.category.dto.response.DrinkUpperCategoryResponse;
 import com.multi.mariage.category.dto.response.FoodCategoryResponse;
-import com.multi.mariage.category.vo.drinkupper.DrinkUpperCategoriesVO;
-import com.multi.mariage.category.vo.drinkupper.DrinkUpperCategoryValuesVO;
 import com.multi.mariage.category.vo.food.FoodCategoriesVO;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class FoodCategoryService {

--- a/backend/src/main/java/com/multi/mariage/category/service/FoodCategoryService.java
+++ b/backend/src/main/java/com/multi/mariage/category/service/FoodCategoryService.java
@@ -1,0 +1,40 @@
+package com.multi.mariage.category.service;
+
+import com.multi.mariage.category.domain.DrinkUpperCategory;
+import com.multi.mariage.category.domain.FoodCategory;
+import com.multi.mariage.category.domain.Region;
+import com.multi.mariage.category.dto.response.DrinkUpperCategoryResponse;
+import com.multi.mariage.category.dto.response.FoodCategoryResponse;
+import com.multi.mariage.category.vo.drinkupper.DrinkUpperCategoriesVO;
+import com.multi.mariage.category.vo.drinkupper.DrinkUpperCategoryValuesVO;
+import com.multi.mariage.category.vo.food.FoodCategoriesVO;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class FoodCategoryService {
+    public FoodCategoryResponse findCategories() {
+
+        List<FoodCategory> categories = Arrays.asList(FoodCategory.values());
+
+        List<FoodCategoriesVO> categoryList = categories.stream()
+                .map(category -> FoodCategoriesVO.builder()
+                        .id(category.getId())
+                        .name(category.getName())
+                        .build())
+                .toList();
+
+        FoodCategoryResponse response = FoodCategoryResponse.builder()
+                .category(categoryList)
+                .length(categoryList.size())
+                .build();
+
+        return response;
+    }
+
+
+}

--- a/backend/src/main/java/com/multi/mariage/category/service/FoodCategoryService.java
+++ b/backend/src/main/java/com/multi/mariage/category/service/FoodCategoryService.java
@@ -18,24 +18,13 @@ import java.util.stream.Collectors;
 @Service
 public class FoodCategoryService {
     public FoodCategoryResponse findFoodCategories() {
-
-        List<FoodCategoriesVO> categoryList = new ArrayList<>();
-
-        getFoodValues(categoryList);
-
-        FoodCategoryResponse response = FoodCategoryResponse.builder()
-                .category(categoryList)
-                .length(categoryList.size())
-                .build();
-
-        return response;
+        List<FoodCategoriesVO> foodValues = getFoodValues();
+        return FoodCategoryResponse.from(foodValues);
     }
 
-    private static void getFoodValues(List<FoodCategoriesVO> categoryList) {
-        for (FoodCategory foodCategory : FoodCategory.values()) {
-            FoodCategoriesVO category = FoodCategoriesVO.from(foodCategory.getId(), foodCategory.getName());
-            categoryList.add(category);
-        }
+    private List<FoodCategoriesVO> getFoodValues() {
+        return Arrays.stream(FoodCategory.values())
+                .map(FoodCategoriesVO::from)
+                .toList();
     }
 }
-

--- a/backend/src/main/java/com/multi/mariage/category/service/FoodCategoryService.java
+++ b/backend/src/main/java/com/multi/mariage/category/service/FoodCategoryService.java
@@ -19,11 +19,9 @@ import java.util.stream.Collectors;
 public class FoodCategoryService {
     public FoodCategoryResponse findFoodCategories() {
 
-        List<FoodCategory> categories = Arrays.asList(FoodCategory.values());
+        List<FoodCategoriesVO> categoryList = new ArrayList<>();
 
-        List<FoodCategoriesVO> categoryList = categories.stream()
-                .map(category -> FoodCategoriesVO.from(category.getId(), category.getName()))
-                .toList();
+        getFoodValues(categoryList);
 
         FoodCategoryResponse response = FoodCategoryResponse.builder()
                 .category(categoryList)
@@ -32,4 +30,12 @@ public class FoodCategoryService {
 
         return response;
     }
+
+    private static void getFoodValues(List<FoodCategoriesVO> categoryList) {
+        for (FoodCategory foodCategory : FoodCategory.values()) {
+            FoodCategoriesVO category = FoodCategoriesVO.from(foodCategory.getId(), foodCategory.getName());
+            categoryList.add(category);
+        }
+    }
 }
+

--- a/backend/src/main/java/com/multi/mariage/category/vo/food/FoodCategoriesVO.java
+++ b/backend/src/main/java/com/multi/mariage/category/vo/food/FoodCategoriesVO.java
@@ -12,8 +12,15 @@ public class FoodCategoriesVO {
     private String name;
 
     @Builder
-    public FoodCategoriesVO(int id, String name) {
+    private FoodCategoriesVO(int id, String name) {
         this.id = id;
         this.name = name;
+    }
+
+    public static FoodCategoriesVO from(int id, String name) {
+        return FoodCategoriesVO.builder()
+                .id(id)
+                .name(name)
+                .build();
     }
 }

--- a/backend/src/main/java/com/multi/mariage/category/vo/food/FoodCategoriesVO.java
+++ b/backend/src/main/java/com/multi/mariage/category/vo/food/FoodCategoriesVO.java
@@ -1,0 +1,19 @@
+package com.multi.mariage.category.vo.food;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Data
+public class FoodCategoriesVO {
+    private int id;
+    private String name;
+
+    @Builder
+    public FoodCategoriesVO(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/backend/src/main/java/com/multi/mariage/category/vo/food/FoodCategoriesVO.java
+++ b/backend/src/main/java/com/multi/mariage/category/vo/food/FoodCategoriesVO.java
@@ -1,5 +1,6 @@
 package com.multi.mariage.category.vo.food;
 
+import com.multi.mariage.category.domain.FoodCategory;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
@@ -17,10 +18,10 @@ public class FoodCategoriesVO {
         this.name = name;
     }
 
-    public static FoodCategoriesVO from(int id, String name) {
+    public static FoodCategoriesVO from(FoodCategory category) {
         return FoodCategoriesVO.builder()
-                .id(id)
-                .name(name)
+                .id(category.getId())
+                .name(category.getName())
                 .build();
     }
 }

--- a/backend/src/test/java/com/multi/mariage/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/multi/mariage/category/controller/CategoryControllerTest.java
@@ -16,9 +16,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class CategoryControllerTest extends ControllerTest {
 
-    @DisplayName("상위 카테고리 조회 테스트")
+    @DisplayName("상위 카테고리를 조회한다.")
     @Test
-    void 상위_카테고리_조회() throws Exception {
+    void 상위_카테고리를_조회한다() throws Exception {
 
         mockMvc.perform(get("/api/categories/upper"))
                 .andDo(print())
@@ -37,9 +37,9 @@ class CategoryControllerTest extends ControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("하위 카테고리 조회 테스트")
+    @DisplayName("하위 카테고리를 조회한다.")
     @Test
-    void 하위_카테고리_조회() throws Exception {
+    void 하위_카테고리를_조회한다() throws Exception {
 
         mockMvc.perform(get("/api/categories/lower"))
                 .andDo(print())
@@ -55,6 +55,25 @@ class CategoryControllerTest extends ControllerTest {
                                         fieldWithPath("category[].categories[].subCategories").description("주류 하위 카테고리"),
                                         fieldWithPath("category[].categories[].subCategories[].name").description("주류 하위 카테고리 지칭"),
                                         fieldWithPath("category[].categories[].subCategories[].value").description("주류 하위 카테고리 명칭")
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("음식 카테고리를 조회한다.")
+    @Test
+    void 음식_카테고리를_조회한다() throws Exception {
+
+        mockMvc.perform(get("/api/categories/food"))
+                .andDo(print())
+                .andDo(document("Category/FindFoodCategory",
+                                preprocessResponse(prettyPrint()),
+                                responseFields(
+                                        fieldWithPath("category").description("음식 카테고리"),
+                                        fieldWithPath("category[].id").description("음식 식별자"),
+                                        fieldWithPath("category[].name").description("음식 명칭"),
+                                        fieldWithPath("length").description("음식 개수")
                                 )
                         )
                 )

--- a/backend/src/test/java/com/multi/mariage/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/multi/mariage/category/controller/CategoryControllerTest.java
@@ -16,9 +16,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class CategoryControllerTest extends ControllerTest {
 
-    @DisplayName("상위 카테고리를 조회한다.")
+    @DisplayName("주류 상위 카테고리를 조회한다.")
     @Test
-    void 상위_카테고리를_조회한다() throws Exception {
+    void 주류_상위_카테고리를_조회한다() throws Exception {
 
         mockMvc.perform(get("/api/categories/upper"))
                 .andDo(print())
@@ -37,9 +37,9 @@ class CategoryControllerTest extends ControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("하위 카테고리를 조회한다.")
+    @DisplayName("주류 하위 카테고리를 조회한다.")
     @Test
-    void 하위_카테고리를_조회한다() throws Exception {
+    void 주류_하위_카테고리를_조회한다() throws Exception {
 
         mockMvc.perform(get("/api/categories/lower"))
                 .andDo(print())

--- a/backend/src/test/java/com/multi/mariage/category/service/FoodCategoryServiceTest.java
+++ b/backend/src/test/java/com/multi/mariage/category/service/FoodCategoryServiceTest.java
@@ -1,11 +1,6 @@
 package com.multi.mariage.category.service;
 
-import com.multi.mariage.category.domain.FoodCategory;
-import com.multi.mariage.category.domain.Region;
-import com.multi.mariage.category.dto.response.DrinkUpperCategoryResponse;
 import com.multi.mariage.category.dto.response.FoodCategoryResponse;
-import com.multi.mariage.category.vo.drinkupper.DrinkUpperCategoriesVO;
-import com.multi.mariage.category.vo.drinkupper.DrinkUpperCategoryValuesVO;
 import com.multi.mariage.category.vo.food.FoodCategoriesVO;
 import com.multi.mariage.common.annotation.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +9,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backend/src/test/java/com/multi/mariage/category/service/FoodCategoryServiceTest.java
+++ b/backend/src/test/java/com/multi/mariage/category/service/FoodCategoryServiceTest.java
@@ -29,11 +29,11 @@ class FoodCategoryServiceTest extends ServiceTest {
         FoodCategoryResponse response = foodCategoryService.findFoodCategories();
 
         assertThat(response).isNotNull();
-        List<FoodCategoriesVO> actual = response.getCategory();
+        List<FoodCategoriesVO> vo = response.getCategory();
 
-        for (FoodCategoriesVO category : actual) {
-            assertThat(category.getId()).isNotNull();
-            assertThat(category.getName()).isNotEmpty();
+        for (FoodCategoriesVO actual : vo) {
+            assertThat(actual.getId()).isNotNull();
+            assertThat(actual.getName()).isNotEmpty();
         }
     }
 

--- a/backend/src/test/java/com/multi/mariage/category/service/FoodCategoryServiceTest.java
+++ b/backend/src/test/java/com/multi/mariage/category/service/FoodCategoryServiceTest.java
@@ -1,0 +1,58 @@
+package com.multi.mariage.category.service;
+
+import com.multi.mariage.category.domain.FoodCategory;
+import com.multi.mariage.category.domain.Region;
+import com.multi.mariage.category.dto.response.DrinkUpperCategoryResponse;
+import com.multi.mariage.category.dto.response.FoodCategoryResponse;
+import com.multi.mariage.category.vo.drinkupper.DrinkUpperCategoriesVO;
+import com.multi.mariage.category.vo.drinkupper.DrinkUpperCategoryValuesVO;
+import com.multi.mariage.category.vo.food.FoodCategoriesVO;
+import com.multi.mariage.common.annotation.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FoodCategoryServiceTest extends ServiceTest {
+
+    FoodCategoryService foodCategoryService = new FoodCategoryService();
+
+    @DisplayName("카테고리를 조회한다.")
+    @Test
+    void 카테고리를_조회한다() {
+
+        FoodCategoryResponse response = foodCategoryService.findFoodCategories();
+
+        assertThat(response).isNotNull();
+        List<FoodCategoriesVO> actual = response.getCategory();
+
+        for (FoodCategoriesVO category : actual) {
+            assertThat(category.getId()).isNotNull();
+            assertThat(category.getName()).isNotEmpty();
+        }
+    }
+
+    @DisplayName("특정한 음식을 조회한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"해산물", "고기/구이", "족발/보쌈", "피자", "치킨"})
+    void 특정한_음식을_조회한다(String food) {
+
+        FoodCategoryResponse response = foodCategoryService.findFoodCategories();
+
+        List<FoodCategoriesVO> categories = response.getCategory();
+
+        FoodCategoriesVO category = categories.stream()
+                .filter(cv -> food.equals(cv.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(category.getName()).isEqualTo(food);
+        assertThat(response.getLength()).isNotNull();
+        assertThat(response.getLength()).isEqualTo(categories.size());
+    }
+}


### PR DESCRIPTION
# 개요


#97 음식 카테고리 조회 기능 추가


## 한 일

- [x] 음식 카테고리 조회 비즈니스 로직 구현
- [x] 테스트 코드 작성

## ETC

```
{
    "category": [
        {
            "id": 1,
            "name": "해산물"
        },
        {
            "id": 2,
            "name": "고기/구이"
        },
        {
            "id": 3,
            "name": "족발/보쌈"
        },
        {
            "id": 4,
            "name": "찜/탕/찌개"
        },
        {
            "id": 5,
            "name": "밥/면"
        },
        {
            "id": 6,
            "name": "피자"
        },
        {
            "id": 7,
            "name": "치킨"
        },
        {
            "id": 8,
            "name": "양식"
        },
        {
            "id": 9,
            "name": "중식"
        },
        {
            "id": 10,
            "name": "돈까스/회/일식"
        },
        {
            "id": 11,
            "name": "아시안"
        },
        {
            "id": 12,
            "name": "멕시코"
        },
        {
            "id": 13,
            "name": "햄버거"
        },
        {
            "id": 14,
            "name": "분식"
        },
        {
            "id": 15,
            "name": "튀김"
        },
        {
            "id": 16,
            "name": "스낵"
        },
        {
            "id": 17,
            "name": "치즈"
        },
        {
            "id": 18,
            "name": "과일"
        },
        {
            "id": 19,
            "name": "디저트"
        },
        {
            "id": 20,
            "name": "기타"
        }
    ],
    "length": 20
}
```
