### PR TITLE
[FE] 리뷰 통계 컴포넌트 내부 퍼센트 바 추가

### DIFF
--- a/frontend/src/components/Bar/PercentageBar/PercentageBar.styled.ts
+++ b/frontend/src/components/Bar/PercentageBar/PercentageBar.styled.ts
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+interface BarProps {
+  percentage: number;
+}
+
+const BarWrapper = styled.div`
+  width: 100%;
+  height: 16px;
+  background-color: rgba(156, 148, 208, 0.2);
+`;
+
+const Bar = styled.div<BarProps>`
+  height: 100%;
+  background-color: #9C94D0;
+  width: ${props => `${props.percentage}%`};
+`;
+
+const Container = styled.div`
+  margin: 0 5px;
+`;
+
+export { BarWrapper, Bar, Container };

--- a/frontend/src/components/Bar/PercentageBar/PercentageBar.tsx
+++ b/frontend/src/components/Bar/PercentageBar/PercentageBar.tsx
@@ -1,0 +1,22 @@
+import * as S from './PercentageBar.styled';
+
+interface PercentageProps {
+    percentage: number;
+}
+
+function PercentageBar({ percentage }: PercentageProps) {
+    
+  return (
+    <div>
+        <S.Container>
+      <S.BarWrapper>
+      <S.Bar
+        percentage={percentage}
+      />
+    </S.BarWrapper>
+    </S.Container>
+    </div>
+  );
+}
+
+export default PercentageBar;

--- a/frontend/src/components/Detail/Review/RateStatistic/RateStatistic.tsx
+++ b/frontend/src/components/Detail/Review/RateStatistic/RateStatistic.tsx
@@ -1,5 +1,5 @@
 import StarRateAverage from '@/components/StarRate/Average/StarRateAverage';
-
+import PercentageBar from '@/components/Bar/PercentageBar/PercentageBar';
 import * as S from './RateStatistic.styled';
 
 function RateStatistic() {
@@ -55,7 +55,7 @@ function RateStatistic() {
                 <StarRateAverage key={rate.id} averageReviewRate={rate.id} />
               </S.Star>
               <S.Graph>
-                <S.TempGraph></S.TempGraph>
+                <S.TempGraph><PercentageBar percentage={rate.value}/></S.TempGraph>
               </S.Graph>
               <S.Count>{rate.value}%</S.Count>
             </S.RateOption>


### PR DESCRIPTION
# 개요

#163 리뷰 통계 컴포넌트 내부 Horizontal Bar 구현

## 한 일

- [X] 리뷰 통계 컴포넌트 내부 바 컴포넌트 구현


## ETC

#### 구현 결과
![image](https://github.com/mariage-kr/mariage/assets/119832853/41301351-c1ad-4bb1-acb2-8a82bfef7dab)

#### 데이터 변경 시
![2023-05-16 14;09;39](https://github.com/mariage-kr/mariage/assets/119832853/f31b0cbe-4de5-444e-a874-b64ce3688023)


