### PR TITLE
[BE] 제품 상세페이지별 제품 조회 기능 추가

### DIFF
--- a/backend/src/main/java/com/multi/mariage/country/domain/Country.java
+++ b/backend/src/main/java/com/multi/mariage/country/domain/Country.java
@@ -14,13 +14,13 @@ public enum Country {
     CHINA(4, "중국", "china");
 
     private int id;
-    private String country;
+    private String value;
     private String flagName;
 
 
-    Country(int id, String country, String flagName) {
+    Country(int id, String value, String flagName) {
         this.id = id;
-        this.country = country;
+        this.value = value;
         this.flagName = flagName;
     }
 }

--- a/backend/src/main/java/com/multi/mariage/country/vo/CountriesVO.java
+++ b/backend/src/main/java/com/multi/mariage/country/vo/CountriesVO.java
@@ -23,7 +23,7 @@ public class CountriesVO {
     public static CountriesVO from(Country country) {
         return CountriesVO.builder()
                 .id(country.getId())
-                .name(country.getCountry())
+                .name(country.getValue())
                 .value(country)
                 .build();
     }

--- a/backend/src/main/java/com/multi/mariage/product/controller/ProductFindController.java
+++ b/backend/src/main/java/com/multi/mariage/product/controller/ProductFindController.java
@@ -1,5 +1,6 @@
 package com.multi.mariage.product.controller;
 
+import com.multi.mariage.product.dto.response.ProductContentResponse;
 import com.multi.mariage.product.dto.response.ProductFindResponse;
 import com.multi.mariage.product.dto.response.ProductInfoResponse;
 import com.multi.mariage.product.dto.response.ProductMainCardResponse;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.repository.query.Param;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,6 +31,12 @@ public class ProductFindController {
     @GetMapping("/user/product/info")
     public ResponseEntity<ProductInfoResponse> findProductInfo(@Param("productId") Long productId) {
         ProductInfoResponse response = productFindService.findProductInfo(productId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/product/detail/{id}")
+    public ResponseEntity<ProductContentResponse> findProductContentById(@PathVariable Long id) {
+        ProductContentResponse response = productFindService.findProductContent(id);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/multi/mariage/product/dto/response/ProductContentResponse.java
+++ b/backend/src/main/java/com/multi/mariage/product/dto/response/ProductContentResponse.java
@@ -1,0 +1,39 @@
+package com.multi.mariage.product.dto.response;
+
+import com.multi.mariage.category.domain.DrinkLowerCategory;
+import com.multi.mariage.category.domain.DrinkUpperCategory;
+import com.multi.mariage.country.domain.Country;
+import com.multi.mariage.product.domain.Product;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Data
+public class ProductContentResponse {
+    private Long id;
+    private Long imageId;
+    private String imageUrl;
+    private String name;
+    private double level;
+    private double reviewRate;
+    private String info;
+    private int countryId;
+    private String country;
+
+    private ProductContentResponse(Product product, String imageUrl, double reviewRate) {
+        this.id = product.getId();
+        this.imageId = product.getImage().getId();
+        this.imageUrl = imageUrl;
+        this.name = String.valueOf(product.getName());
+        this.level = product.getLevel().getValue();
+        this.reviewRate = reviewRate;
+        this.info = String.valueOf(product.getInfo());
+        this.countryId = product.getCountry().getId();
+        this.country = product.getCountry().getValue();
+    }
+
+    public static ProductContentResponse from(Product product, String imageUrl, double reviewRate) {
+        return new ProductContentResponse(product, imageUrl, reviewRate);
+    }
+}

--- a/backend/src/main/java/com/multi/mariage/product/service/ProductFindService.java
+++ b/backend/src/main/java/com/multi/mariage/product/service/ProductFindService.java
@@ -11,7 +11,6 @@ import com.multi.mariage.product.exception.ProductErrorCode;
 import com.multi.mariage.product.exception.ProductException;
 import com.multi.mariage.product.vo.ProductsVO;
 import com.multi.mariage.review.domain.Review;
-import com.multi.mariage.review.service.ReviewFindService;
 import com.multi.mariage.storage.service.ImageService;
 import com.multi.mariage.weather.service.WeatherService;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
@@ -30,7 +28,6 @@ public class ProductFindService {
     private final ImageService imageService;
     private final ProductRepository productRepository;
     private final WeatherService weatherService;
-    private final ReviewFindService reviewFindService;
 
     public ProductFindResponse findProducts() {
         List<ProductsVO> productValues = getProductValues();

--- a/backend/src/main/java/com/multi/mariage/product/service/ProductFindService.java
+++ b/backend/src/main/java/com/multi/mariage/product/service/ProductFindService.java
@@ -3,6 +3,7 @@ package com.multi.mariage.product.service;
 import com.multi.mariage.country.domain.Country;
 import com.multi.mariage.product.domain.Product;
 import com.multi.mariage.product.domain.ProductRepository;
+import com.multi.mariage.product.dto.response.ProductContentResponse;
 import com.multi.mariage.product.dto.response.ProductFindResponse;
 import com.multi.mariage.product.dto.response.ProductInfoResponse;
 import com.multi.mariage.product.dto.response.ProductMainCardResponse;
@@ -10,6 +11,7 @@ import com.multi.mariage.product.exception.ProductErrorCode;
 import com.multi.mariage.product.exception.ProductException;
 import com.multi.mariage.product.vo.ProductsVO;
 import com.multi.mariage.review.domain.Review;
+import com.multi.mariage.review.service.ReviewFindService;
 import com.multi.mariage.storage.service.ImageService;
 import com.multi.mariage.weather.service.WeatherService;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
@@ -27,6 +30,7 @@ public class ProductFindService {
     private final ImageService imageService;
     private final ProductRepository productRepository;
     private final WeatherService weatherService;
+    private final ReviewFindService reviewFindService;
 
     public ProductFindResponse findProducts() {
         List<ProductsVO> productValues = getProductValues();
@@ -53,6 +57,15 @@ public class ProductFindService {
         String imageUrl = imageService.getImageUrl(product.getImage().getName());
 
         return ProductInfoResponse.from(product, imageUrl);
+    }
+
+    public ProductContentResponse findProductContent(Long productId) {
+        Product product = findById(productId);
+        String imageUrl = imageService.getImageUrl(product.getImage().getName());
+        List<Review> reviews = product.getReviews();
+        double reviewRate = getReviewAverageRate(reviews);
+
+        return ProductContentResponse.from(product, imageUrl, reviewRate);
     }
 
     public Product findById(Long id) {
@@ -94,7 +107,7 @@ public class ProductFindService {
                 .productImageUrl(imageService.getImageUrl(product.getImage().getName()))
                 .reviewCount(reviews.size())
                 .reviewRate(getReviewAverageRate(reviews))
-                .country(country.getCountry())
+                .country(country.getValue())
                 .countryImageUrl(imageService.getImageUrl(country.getFlagName()))
                 .build();
     }

--- a/backend/src/main/java/com/multi/mariage/product/vo/ProductsVO.java
+++ b/backend/src/main/java/com/multi/mariage/product/vo/ProductsVO.java
@@ -43,7 +43,7 @@ public class ProductsVO {
                 .info(product.getInfo())
                 .upperCategory(upperCategory.getName())
                 .lowerCategory(lowerCategory.getName())
-                .country(country.getCountry())
+                .country(country.getValue())
                 .imageId(product.getImage().getId())
                 .imageUrl(imageUrl)
                 .build();

--- a/backend/src/test/java/com/multi/mariage/product/controller/ProductFindControllerTest.java
+++ b/backend/src/test/java/com/multi/mariage/product/controller/ProductFindControllerTest.java
@@ -9,6 +9,7 @@ import com.multi.mariage.product.domain.Product;
 import com.multi.mariage.storage.domain.Image;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -20,6 +21,32 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class ProductFindControllerTest extends ControllerTest {
+    @DisplayName("상세페이지의 제품 정보를 조회한다.")
+    @Test
+    void 상세페이지의_제품_정보를_조회한다() throws Exception {
+
+        Product product = saveProduct(ProductFixture.참이슬, saveImage(ImageFixture.JPEG_IMAGE).getId());
+        Long productId = product.getId();
+
+        mockMvc.perform(get("/api/product/detail/" + productId))
+                .andDo(print())
+                .andDo(document("Product/Detail",
+                                preprocessResponse(prettyPrint()),
+                                responseFields(
+                                        fieldWithPath("id").description("제품 식별자"),
+                                        fieldWithPath("imageId").description("제품 이미지 식별자"),
+                                        fieldWithPath("imageUrl").description("제품 이미지 url"),
+                                        fieldWithPath("name").description("제품 이름"),
+                                        fieldWithPath("level").description("제품의 도수"),
+                                        fieldWithPath("reviewRate").description("제품에 대한 리뷰 평점"),
+                                        fieldWithPath("info").description("제품 정보"),
+                                        fieldWithPath("countryId").description("제품의 제조국 식별자"),
+                                        fieldWithPath("country").description("제품의 제조국 이름")
+                                )
+                        )
+                )
+                .andExpect(status().is(HttpStatus.OK.value()));
+    }
 
     @DisplayName("전체기간 동안 가장많이 리뷰가 작성된 제품들을 추천한다.")
     @Test

--- a/backend/src/test/java/com/multi/mariage/product/service/ProductFindServiceTest.java
+++ b/backend/src/test/java/com/multi/mariage/product/service/ProductFindServiceTest.java
@@ -5,6 +5,7 @@ import com.multi.mariage.common.fixture.*;
 import com.multi.mariage.member.domain.Member;
 import com.multi.mariage.product.domain.Product;
 import com.multi.mariage.product.dto.request.ProductSaveRequest;
+import com.multi.mariage.product.dto.response.ProductContentResponse;
 import com.multi.mariage.product.dto.response.ProductFindResponse;
 import com.multi.mariage.product.dto.response.ProductMainCardResponse;
 import com.multi.mariage.product.vo.ProductsVO;
@@ -29,7 +30,6 @@ class ProductFindServiceTest extends ServiceTest {
 
         savedImage1 = storageRepository.save(image);
         ProductSaveRequest saveRequest = ProductFixture.참이슬.toProductSaveRequest(savedImage1.getId());
-
         참이슬 = productModifyService.save(saveRequest);
     }
 
@@ -45,6 +45,17 @@ class ProductFindServiceTest extends ServiceTest {
             assertThat(actual.getId()).isNotNull();
             assertThat(actual.getName()).isNotEmpty();
         }
+    }
+
+    @DisplayName("상세페이지의 제품 정보를 조회한다.")
+    @Test
+    void 상세페이지의_제품_정보를_조회한다() {
+        Image image = new Image(ProductFixture.산토리_위스키.getImageName());
+        Image 산토리_위스키_이미지 = storageRepository.save(image);
+        Product 산토리_위스키 = saveProduct(ProductFixture.산토리_위스키, 산토리_위스키_이미지.getId());
+        Long productId = 산토리_위스키.getId();
+        ProductContentResponse response = productFindService.findProductContent(productId);
+        assertThat(response).isNotNull();
     }
 
     @DisplayName("전체기간_동안_가장_많은_리뷰가_달린_제품들을_추천한다")


### PR DESCRIPTION
# 개요


#244 제품 상세페이지의 제품 정보를 제공한다.


## 한 일

- [X] 제품 상세페이지 조회 비즈니스 로직 구현
- [x] 테스트 코드 작성

## ETC
JSON
```
{
    "id": 3,
    "imageId": 3,
    "imageUrl": "http://localhost:8080/imageproduct/ganbareotosang.png",
    "name": "간바레오또상",
    "level": 14.5,
    "reviewRate": 0.0,
    "info": "‘아빠 힘내세요!’ 라는 뜻의 간바레 오또상!\n 일본 버블 붕괴 후 장기불황에 지쳐있는 샐러리맨들에게 싼값에 좋은 사케를 공급하고자 하는 마음으로 빚어진 사케입니다.",
    "countryId": 3,
    "country": "일본"
}
```
