### PR TITLE
[FIX] Github Action 메시지 수정

### DIFF
--- a/.github/workflows/mariage-pr.yml
+++ b/.github/workflows/mariage-pr.yml
@@ -115,7 +115,7 @@ jobs:
             Commit : ${{ env.COMMIT_URL }}
 
       - name: Send Failed Result to Discord 📩
-        if: ${{ needs.Backend_CI.result != 'success' || needs.Frontend_CI.result != 'success' }}
+        if: ${{ needs.Backend_CI.result == 'failure' || needs.Frontend_CI.result == 'failure' }}
         uses: appleboy/discord-action@master
         with:
           webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}


### PR DESCRIPTION
# 개요

테스트를 성공해도 실패와 성공의 메시지가 같이 전달되는 현상을 방지합니다.

## 한 일

- [x]  action 수정