### PR TITLE
[FIX] 궁합 음식 평점순 랭킹 조회 시 표기 수정

### DIFF
--- a/backend/src/main/java/com/multi/mariage/category/domain/Food.java
+++ b/backend/src/main/java/com/multi/mariage/category/domain/Food.java
@@ -45,6 +45,6 @@ public class Food {
     /* 비즈니스 로직 */
     public void changeTotalFoodRate(int rate) {
         totalFoodRate += rate;
-        avgFoodRate = (double) totalFoodRate / reviews.size();
+        avgFoodRate = Math.round(((double) totalFoodRate / reviews.size()) * 10) / 10.0;
     }
 }

--- a/backend/src/main/java/com/multi/mariage/global/data/LoaderData.java
+++ b/backend/src/main/java/com/multi/mariage/global/data/LoaderData.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
-//@Profile("dev")
+@Profile("dev")
 public class LoaderData {
 
     private static Member 마리;


### PR DESCRIPTION
# 개요

#328 궁합 음식 평점순 랭킹 조회 시 표기 수정


## 한 일

- [X] 궁합 음식 평점순 랭킹 조회 시 소수 첫째자리까지만 표기되도록 수정

## ETC
**변경 전**
![image](https://github.com/mariage-kr/mariage/assets/119832853/1a4fc397-ad80-42b1-a1ae-a45f72549def)

**변경 후**
```
"foodRateRanking": [
        {
            "foodId": 2,
            "category": "고기/구이",
            "avgFoodRate": 4.0
        },
        {
            "foodId": 6,
            "category": "피자",
            "avgFoodRate": 3.7
        },
        {
            "foodId": 7,
            "category": "치킨",
            "avgFoodRate": 3.0
        },
        {
            "foodId": 10,
            "category": "돈까스/회/일식",
            "avgFoodRate": 3.0
        }
    ],
```
